### PR TITLE
Add python implementation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Published RFC Draft: <https://tools.ietf.org/html/draft-inadarei-api-health-chec
 1. Node.js: https://github.com/inadarei/maikai
 2. Golang: https://github.com/nelkinda/health-go
 3. .NET: https://github.com/RockLib/RockLib.HealthChecks
+4. Python: https://github.com/Colin-b/healthpy
 
 ## References
 


### PR DESCRIPTION
This implementation also allows to tweak details and status to handle custom needs depending on the underlying check system. For example it allows to use a specific http error code for warning as Consul only consider a single http code as warning.